### PR TITLE
Flesh out oanda_historic_candles.py

### DIFF
--- a/oanda_historic_candles.py
+++ b/oanda_historic_candles.py
@@ -1,9 +1,45 @@
+import argparse
 import datetime
 import json
 import time
 import urllib2
 
 DEFAULT_FILE = 'data.csv'
+MONTH_SEC = 60 * 60 * 24 * 30
+
+def WriteMonthOfData(month, year, f, startTime=None):
+    if not startTime:
+        if not year:
+            raise 'if you dont provide startTime you must provide a year'
+        if not month:
+            month = 1 # default to jan
+        month = '0' + str(month)
+        date = "%s-%s-01" % (year, month)
+        dt = datetime.datetime.strptime(date, '%Y-%m-%d')
+        start = int(time.mktime(dt.timetuple()))
+    else:
+        start = startTime
+    endTime = start + MONTH_SEC
+
+    t = start
+    while t < endTime:
+        # get finer grain number of records
+        # 5000 ensures a month of data is retrieved without
+        # getting our requests throttled but means we
+        # can overshoot by a lot
+        data = GetOandaCandle(start, 5000)
+        writeToFile(data, f)
+        t = int(data['candles'][-1]['time'][:-6])
+    return data['candles'][-1]['time'][:-6]
+
+# TODO do something to avoid hitting the rate limit
+def WriteYearOfData(year, f):
+    lastTime = None
+    for i in xrange(1, 13):
+        if lastTime:
+            lastTime = WriteMonthOfData(i, year, f, lastTime)
+        else:
+            lastTime = WriteMonthOfData(i, year, f)
 
 def GetOandaCandle(startTime, count):
     header = {"X-Accept-Datetime-Format": "UNIX"}
@@ -28,14 +64,22 @@ def writeToFile(data, outfile):
     if 'candles' not in data:
         raise Exception('No candles in this data you fuck face')
     candles = data['candles']
-    with open(outfile, 'w') as f:
+    with open(outfile, 'a') as f:
         for candle in candles:
             fmtdCandle = fmtCandle(candle)
             f.write(fmtdCandle)
 
 def main():
-    # TODO allow user specify a year or month or whatever this goes and gets a years or month or whatever worth of data and writes it to a csv (that eventually the user will specify)
-    data = GetOandaCandle(1471365995, 3)
-    writeToFile(data, DEFAULT_FILE)
+    parser = argparse.ArgumentParser(description='Specify time period to retrieve data from oanda')
+    parser.add_argument('--year', required=True, type=int, help='year to get data for')
+    parser.add_argument('--month', required=False, type=int, help='month to get data for')
+    parser.add_argument('--outfile', required=False, help='file to write data to')
+
+    args = parser.parse_args()
+
+    if args.month:
+        WriteMonthOfData(args.month, args.year, DEFAULT_FILE)
+    else:
+        WriteYearOfData(args.year, DEFAULT_FILE)
 
 main()


### PR DESCRIPTION
Add options to specify timeframe for oanda_historic_candles

Issues:
    - oanda is missing data. ie in 2004 they only return
    one candle per day some days
    - i get 5k records with each request. this allows us
    to get a month of data (when they actually have records
    every 5s) without hit the api rate limiting but means we
    way overshoot the desired time frame when data is sparse
